### PR TITLE
fixed sign up/sign in with otp for new users

### DIFF
--- a/app/auth/sign-up.tsx
+++ b/app/auth/sign-up.tsx
@@ -54,7 +54,7 @@ export default function SignUpScreen() {
         // Skip automatic sign-in attempt and always show verification message
         Alert.alert(
           "Account Created",
-          "Your account has been created successfully. Please check your email for a verification link before signing in.",
+          "Your account has been created successfully. You can sign in now!",
           [
             {
               text: "OK",


### PR DESCRIPTION
- Users can create a new account with both "sign up" and "sign in with OTP", **note that if they use OTP the first time they'll always need to use it to sign in!**
- Sign up and sign in with OTP trigger a function in SQL that automatically creates a row entry in the 'profiles' table in Supabase